### PR TITLE
Support ACF standard format_value.

### DIFF
--- a/fields/acf-price-common.php
+++ b/fields/acf-price-common.php
@@ -49,7 +49,7 @@ abstract class acf_price_common extends acf_field
         return $value;
     }
 
-    public function load_value( $value, $post_id, $field )
+    public function format_value( $value, $post_id, $field )
     {
         $format = $this->parse_format( $field['format'] );
 


### PR DESCRIPTION
Rename load_value to format_value to be able to fetch the value without the formatting. #7 